### PR TITLE
Allow user to set a base URL path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # webthing Changelog
 
+## [Unreleased]
+### Added
+- Ability to set a base URL path on server.
+
 ## [0.11.0] - 2019-01-16
 ### Changed
 - `WebThingServer::new()` can now take a configuration function which can add additional API routes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webthing"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Mozilla IoT <iot@mozilla.com>"]
 repository = "https://github.com/mozilla-iot/webthing-rust"
 homepage = "https://github.com/mozilla-iot/webthing-rust"
@@ -19,7 +19,7 @@ libmdns = "0.2"
 openssl = { version = "0.10", optional = true }
 serde_json = "1.0"
 uuid = { version = "0.7", features = ["v4"] }
-valico = "2.3"
+valico = "3.0"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/examples/multiple-things.rs
+++ b/examples/multiple-things.rs
@@ -333,6 +333,7 @@ fn main() {
         None,
         Box::new(Generator),
         None,
+        None,
     );
     server.create();
     server.start();

--- a/examples/restart-server-externally.rs
+++ b/examples/restart-server-externally.rs
@@ -249,6 +249,8 @@ fn main() {
         None,
         None,
         Box::new(Generator),
+        None,
+        None,
     );
     let server_address = server.create();
 

--- a/examples/single-thing.rs
+++ b/examples/single-thing.rs
@@ -248,6 +248,7 @@ fn main() {
         None,
         Box::new(Generator),
         None,
+        None,
     );
     server.create();
     server.start();


### PR DESCRIPTION
This can be useful when operating behind a proxy, for example.