### PR TITLE
Bump libmdns to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4.22", default_features = false, features = ["std"] }
 futures = { version = "0.3", optional = true }
 hostname = { version = "0.3", optional = true }
 if-addrs = { version = "0.7", optional = true }
-libmdns = { version = "0.6", optional = true }
+libmdns = { version = "0.7", optional = true }
 openssl = { version = "0.10", optional = true }
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
This brings several improvements and bugfixes. Including spec compliance, support for multiple network interfaces, and removal of a panic in certain circumstances.

But lets be honest, my major motivation for advocating the primary dependants of libmdns use recent versions... is so the graph on crates.io looks neater.